### PR TITLE
Added override scope method to override matching routes check

### DIFF
--- a/lib/aygabtu/scope/base.rb
+++ b/lib/aygabtu/scope/base.rb
@@ -5,6 +5,7 @@ require_relative 'visiting_with'
 require_relative 'requiring'
 require_relative 'static_dynamic'
 require_relative 'remaining'
+require_relative 'override'
 
 module Aygabtu
   module Scope
@@ -28,7 +29,8 @@ module Aygabtu
         VisitingWith,
         Requiring,
         StaticDynamic,
-        Remaining
+        Remaining,
+        Override
       ]
 
       module BasicBehaviour
@@ -49,6 +51,7 @@ module Aygabtu
       include BasicBehaviour
 
       include(*COMPONENTS)
+      include(*COMPONENTS.select { |component| component.respond_to? :override_behavior }.map(&:override_behavior))
 
       def segments
         if split_once = segments_split_once

--- a/lib/aygabtu/scope/override.rb
+++ b/lib/aygabtu/scope/override.rb
@@ -1,0 +1,40 @@
+module Aygabtu
+  module Scope
+
+    # ATTENTION
+    #
+    # This is a *temporary* feature to work around certain bugs related
+    # to traversing remaining routes multiple times
+    #
+    # See: https://github.com/9elements/aygabtu/issues/5
+
+    module Override
+
+      def override(aygabtu_routes)
+        new_data = @data.dup.merge(overrides: aygabtu_routes)
+        self.class.new(new_data)
+      end
+
+      module OverrideBehavior
+        def matches_route?(route)
+          return super unless @data.key?(:overrides)
+
+          @data[:overrides].include?(route)
+        end
+      end
+
+      def inspect_data
+        return super unless overrides = @data[:overrides]
+        super.merge(override: overrides.map(&:inspect).join('; '))
+      end
+
+      def self.factory_methods
+        [:override]
+      end
+
+      def self.override_behavior
+        OverrideBehavior
+      end
+    end
+  end
+end


### PR DESCRIPTION
Used as a _temporary_ fix for https://github.com/9elements/aygabtu/issues/5

```
remaining do
  override(aygabtu_matching_routes) do
    visit
    visit_with(mobile_version: true)
  end
end
```

I suggest to add this to the gem, maybe as an official feature.
